### PR TITLE
Improving date formatter to have default values for formats.

### DIFF
--- a/FuzeUtils/Classes/FZDateFormatter.swift
+++ b/FuzeUtils/Classes/FZDateFormatter.swift
@@ -9,6 +9,9 @@ import UIKit
 
 public class FZDateFormatter {
     
+    public static var defaultInputDateFormat: String?
+    public static var defaultOutputDateFormat: String?
+    
     public static func getFormattedDateString(date: Date, outputDateFormat: String, locale: String? = nil,
                                        amSymbol: String? = nil, pmSymbol: String? = nil) -> String {
         
@@ -29,17 +32,25 @@ public class FZDateFormatter {
         return outputDateFormatter.string(from: date)
     }
     
-    public static func convertDateFormat(dateString: String, inputDateFormat: String, outputDateFormat: String,
-                                        locale: String? = nil, amSymbol: String? = nil,
-                                        pmSymbol: String? = nil) -> String {
+    public static func convertDateFormat(dateString: String, inputDateFormat: String? = nil, outputDateFormat: String? = nil,
+                                        locale: String? = nil, amSymbol: String? = nil, pmSymbol: String? = nil) -> String {
         
+        let inputDateFormat = (inputDateFormat != nil) ? inputDateFormat
+            : (self.defaultInputDateFormat != nil) ? self.defaultInputDateFormat : nil
+        let outputDateFormat = (outputDateFormat != nil) ? outputDateFormat
+            : (self.defaultOutputDateFormat != nil) ? self.defaultOutputDateFormat : nil
+        
+        guard inputDateFormat != nil, let finalOutputDateFormat = outputDateFormat else {
+            return ""
+        }
+
         let inputDateFormatter = DateFormatter()
         inputDateFormatter.dateFormat = inputDateFormat
         guard let outputDate = inputDateFormatter.date(from: dateString) else {
             return dateString
         }
         
-        return FZDateFormatter.getFormattedDateString(date: outputDate, outputDateFormat: outputDateFormat,
+        return FZDateFormatter.getFormattedDateString(date: outputDate, outputDateFormat: finalOutputDateFormat,
                                                       locale: locale, amSymbol: amSymbol, pmSymbol: pmSymbol)
     }
 }


### PR DESCRIPTION
FZDateFormatter now has default values for the date formats.
Calling the dateFormatter specifying dateFormats in the calls will have priority over the default values.